### PR TITLE
Windows VC15 compilation

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -10,7 +10,7 @@ if (PHP_BCGEN != "no") {
 		AC_DEFINE('HAVE_BCGEN_FILE_CACHE', 1, 'Define to enable file based caching (experimental)');
 	}
 
-	ZEND_EXTENSION('bcgen', "\
+	EXTENSION('bcgen', "\
 		ZendAccelerator.c \
 		zend_accelerator_debug.c \
 		zend_accelerator_module.c \

--- a/zend_accelerator_module.c
+++ b/zend_accelerator_module.c
@@ -180,7 +180,7 @@ static ZEND_FUNCTION(bcgen_compile_file)
 
     ZCG(outfilename) = emalloc(outscript_name_len + 1);
     memcpy(ZCG(outfilename), outscript_name, outscript_name_len);
-    ZCG(outfilename)[outscript_name_len + 1] = "\0";
+    ZCG(outfilename)[outscript_name_len + 1] = '\0';
     
 	handle.filename = script_name;
 	handle.free_filename = 0;


### PR DESCRIPTION
Windows: fix ZEND_EXTENSION() -> EXTENSION()

It is required to be supported by phpsdk's configure.
