### PR TITLE
Windows: fix ZEND_EXTENSION() -> EXTENSION()

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -4,7 +4,7 @@ ARG_ENABLE("bcgen", "whether to enable Zend bcgen support", "yes");
 
 if (PHP_BCGEN != "no") {
 
-	ZEND_EXTENSION('bcgen', "\
+	EXTENSION('bcgen', "\
 		ZendAccelerator.c \
 		zend_accelerator_debug.c \
 		zend_accelerator_module.c \


### PR DESCRIPTION
Usage for testing with master (7.4). Other maintenance branch
can be selected. Be carefull to use the same branch for bcgen and
php-sdk source repository:

 # Follow README.md -
 # https://github.com/Microsoft/php-sdk-binary-tools/blob/master/README.md
$ cd C:\
$ git clone https://github.com/Microsoft/php-sdk-binary-tools.git c:\php-sdk
$ cd c:\php-sdk
$ phpsdk-vc15-x64.bat # Visual Studio 2017 / Windows 64 bits
$ phpsdk_buildtree phpmaster
$ git clone https://github.com/php/php-src.git
$ cd C:\php-sdk\phpmaster\vc15\x64\php-src
$ git checkout PHP-7.2
$ phpsdk_deps --update --branch 7.2 # 'master' or '7.2'
$ buildconf
$ configure --enable-json --enable-sockets --enable-hash --enable-cli \
   --enable-cgi --enable-session --enable-calendar --enable-ipv6 \
   --enable-mbstring --enable-fileinfo --enable-zlib --disable-bcgen
$ nmake
$ nmake install
 # build pecl - bcgen
$ mkdir C:\php-sdk\phpmaster\vc15\x64\pecl
$ cd C:\php-sdk\phpmaster\vc15\x64\pecl
$ git clone https://github.com/nanosonde/bcgen.git
$ git checkout PHP-7.2 # current default is PHP-7.2
$ cd C:\php-sdk\phpmaster\vc15\x64\php-src
$ buildconf --force
$ configure --disable-all --enable-cli --enable-cgi --enable-bcgen
$ nmake