### PR TITLE
Windows: fix ZEND_EXTENSION() -> EXTENSION()

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -10,7 +10,7 @@ if (PHP_BCGEN != "no") {
 		AC_DEFINE('HAVE_BCGEN_FILE_CACHE', 1, 'Define to enable file based caching (experimental)');
 	}
 
-	ZEND_EXTENSION('bcgen', "\
+	EXTENSION('bcgen', "\
 		ZendAccelerator.c \
 		zend_accelerator_debug.c \
 		zend_accelerator_module.c \

--- a/zend_accelerator_module.c
+++ b/zend_accelerator_module.c
@@ -180,7 +180,7 @@ static ZEND_FUNCTION(bcgen_compile_file)
 
     ZCG(outfilename) = emalloc(outscript_name_len + 1);
     memcpy(ZCG(outfilename), outscript_name, outscript_name_len);
-    ZCG(outfilename)[outscript_name_len + 1] = "\0";
+    ZCG(outfilename)[outscript_name_len + 1] = '\0';
     
 	handle.filename = script_name;
 	handle.free_filename = 0;


### PR DESCRIPTION
Usage for testing with master (7.4). Other maintenance branch
can be selected. Be carefull to use the same branch for bcgen and
php-sdk source repository:

 # Follow README.md -
 # https://github.com/Microsoft/php-sdk-binary-tools/blob/master/README.md
$ cd C:\
$ git clone https://github.com/Microsoft/php-sdk-binary-tools.git c:\php-sdk
$ cd c:\php-sdk
$ phpsdk-vc15-x64.bat # Visual Studio 2017 / Windows 64 bits
$ phpsdk_buildtree phpmaster
$ git clone https://github.com/php/php-src.git
$ cd C:\php-sdk\phpmaster\vc15\x64\php-src
$ phpsdk_deps --update --branch master # 'master' or '7.2'
$ buildconf
$ configure --enable-json --enable-sockets --enable-hash --enable-cli \
   --enable-cgi --enable-session --enable-calendar --enable-ipv6 \
   --enable-mbstring --enable-fileinfo --enable-zlib --disable-bcgen
$ nmake
$ nmake install
 # build pecl - bcgen
$ mkdir C:\php-sdk\phpmaster\vc15\x64\pecl
$ cd C:\php-sdk\phpmaster\vc15\x64\pecl
$ git clone https://github.com/nanosonde/bcgen.git
$ git checkout master # current default is PHP-7.2
$ cd C:\php-sdk\phpmaster\vc15\x64\php-src
$ buildconf --force
$ configure --disable-all --enable-cli --enable-cgi --enable-bcgen
$ nmake